### PR TITLE
[Merge from master]tolerate fallocate failure and print IO error in debug form (#225)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Bug Fixes
+
+* Unconditionally tolerate `fallocate` failures as a fix to its portability issue. Errors other than `EOPNOTSUPP` will still emit a warning.
+
 ## [0.2.0] - 2022-05-25
 
 ### Bug Fixes

--- a/src/env/default.rs
+++ b/src/env/default.rs
@@ -152,18 +152,18 @@ impl LogFd {
         });
         #[cfg(target_os = "linux")]
         {
-            fcntl::fallocate(
+            if let Err(e) = fcntl::fallocate(
                 self.0,
                 fcntl::FallocateFlags::empty(),
                 offset as i64,
                 size as i64,
-            )
-            .map_err(|e| from_nix_error(e, "fallocate"))
+            ) {
+                if e != nix::Error::EOPNOTSUPP {
+                    return Err(from_nix_error(e, "fallocate"));
+                }
+            }
         }
-        #[cfg(not(target_os = "linux"))]
-        {
-            Ok(())
-        }
+        Ok(())
     }
 }
 

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -13,7 +13,7 @@ pub enum Error {
     InvalidArgument(String),
     #[error("Corruption: {0}")]
     Corruption(String),
-    #[error("IO Error: {0}")]
+    #[error("IO Error: {0:?}")]
     Io(#[from] IoError),
     #[error("Codec Error: {0}")]
     Codec(#[from] CodecError),

--- a/src/file_pipe_log/log_file.rs
+++ b/src/file_pipe_log/log_file.rs
@@ -5,12 +5,14 @@
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::sync::Arc;
 
+use log::warn;
+
+use crate::env::{FileSystem, Handle, WriteExt};
 use crate::metrics::*;
 use crate::pipe_log::FileBlockHandle;
 use crate::{Error, Result};
 
 use super::format::{LogFileFormat, Version};
-use crate::env::{FileSystem, Handle, WriteExt};
 
 /// Maximum number of bytes to allocate ahead.
 const FILE_ALLOCATE_SIZE: usize = 2 * 1024 * 1024;
@@ -97,7 +99,9 @@ impl<F: FileSystem> LogFileWriter<F> {
                     target_size_hint.saturating_sub(self.capacity),
                 ),
             );
-            self.writer.allocate(self.capacity, alloc)?;
+            if let Err(e) = self.writer.allocate(self.capacity, alloc) {
+                warn!("log file allocation failed: {}", e);
+            }
             self.capacity += alloc;
         }
         self.writer.write_all(buf)?;


### PR DESCRIPTION
* tolerate fallocate failure and print IO error in debug form

Signed-off-by: tabokie <xy.tao@outlook.com>

* update CHANGELOG.md

Signed-off-by: tabokie <xy.tao@outlook.com>

* only tolerate e=95

Signed-off-by: tabokie <xy.tao@outlook.com>

* still tolerate unconditionally

Signed-off-by: tabokie <xy.tao@outlook.com>

* update doc

Signed-off-by: tabokie <xy.tao@outlook.com>

* add a failpoint test

Signed-off-by: tabokie <xy.tao@outlook.com>