### PR TITLE
[Fix Merge conflicts]Record perf contexts to the write procedure (#227)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Unconditionally tolerate `fallocate` failures as a fix to its portability issue. Errors other than `EOPNOTSUPP` will still emit a warning.
 
+### New Features
+
+* Add `PerfContext` which records detailed time breakdown of the write process to thread-local storage.
+
 ### Public API Changes
 
 * Add `is_empty` to `Engine` API.

--- a/src/engine.rs
+++ b/src/engine.rs
@@ -15,16 +15,14 @@ use crate::consistency::ConsistencyChecker;
 use crate::env::{DefaultFileSystem, FileSystem};
 use crate::event_listener::EventListener;
 use crate::file_pipe_log::debug::LogItemReader;
-use crate::file_pipe_log::{
-    DefaultMachineFactory, FilePipeLog, FilePipeLogBuilder, RecoveryConfig,
-};
+use crate::file_pipe_log::{DefaultMachineFactory, FilePipeLog, FilePipeLogBuilder};
 use crate::log_batch::{Command, LogBatch, MessageExt};
 use crate::memtable::{EntryIndex, MemTableRecoverContextFactory, MemTables};
 use crate::metrics::*;
 use crate::pipe_log::{FileBlockHandle, FileId, LogQueue, PipeLog};
 use crate::purge::{PurgeHook, PurgeManager};
 use crate::write_barrier::{WriteBarrier, Writer};
-use crate::{Error, GlobalStats, Result};
+use crate::{perf_context, Error, GlobalStats, Result};
 
 const METRICS_FLUSH_INTERVAL: Duration = Duration::from_secs(30);
 
@@ -141,15 +139,16 @@ where
         let start = Instant::now();
         let len = log_batch.finish_populate(self.cfg.batch_compression_threshold.0 as usize)?;
         let block_handle = {
-            let mut writer = Writer::new(log_batch, sync, start);
+            let mut writer = Writer::new(log_batch, sync);
+            // Snapshot and clear the current perf context temporarily, so the write group
+            // leader will collect the perf context diff later.
+            let mut perf_context = take_perf_context();
+            let before_enter = Instant::now();
             if let Some(mut group) = self.write_barrier.enter(&mut writer) {
                 let now = Instant::now();
-                let _t = StopWatch::new_with(&ENGINE_WRITE_LEADER_DURATION_HISTOGRAM, now);
+                let _t = StopWatch::new_with(&*ENGINE_WRITE_LEADER_DURATION_HISTOGRAM, now);
                 for writer in group.iter_mut() {
-                    ENGINE_WRITE_PREPROCESS_DURATION_HISTOGRAM.observe(
-                        now.saturating_duration_since(writer.start_time)
-                            .as_secs_f64(),
-                    );
+                    writer.entered_time = Some(now);
                     sync |= writer.sync;
                     let log_batch = writer.get_payload();
                     let res = if !log_batch.is_empty() {
@@ -166,6 +165,7 @@ where
                     };
                     writer.set_output(res);
                 }
+                perf_context!(log_write_duration).observe_since(now);
                 if let Err(e) = self.pipe_log.maybe_sync(LogQueue::Append, sync) {
                     panic!(
                         "Cannot sync {:?} queue due to IO error: {}",
@@ -173,7 +173,20 @@ where
                         e
                     );
                 }
+                // Pass the perf context diff to all the writers.
+                let diff = get_perf_context();
+                for writer in group.iter_mut() {
+                    writer.perf_context_diff = diff.clone();
+                }
             }
+            let entered_time = writer.entered_time.unwrap();
+            ENGINE_WRITE_PREPROCESS_DURATION_HISTOGRAM
+                .observe(entered_time.saturating_duration_since(start).as_secs_f64());
+            perf_context.write_wait_duration +=
+                entered_time.saturating_duration_since(before_enter);
+            debug_assert_eq!(writer.perf_context_diff.write_wait_duration, Duration::ZERO);
+            perf_context += &writer.perf_context_diff;
+            set_perf_context(perf_context);
             writer.finish()?
         };
 
@@ -185,8 +198,9 @@ where
                 listener.post_apply_memtables(block_handle.id);
             }
             let end = Instant::now();
-            ENGINE_WRITE_APPLY_DURATION_HISTOGRAM
-                .observe(end.saturating_duration_since(now).as_secs_f64());
+            let apply_duration = end.saturating_duration_since(now);
+            ENGINE_WRITE_APPLY_DURATION_HISTOGRAM.observe(apply_duration.as_secs_f64());
+            perf_context!(apply_duration).observe(apply_duration);
             now = end;
         }
         ENGINE_WRITE_DURATION_HISTOGRAM.observe(now.saturating_duration_since(start).as_secs_f64());
@@ -201,7 +215,7 @@ where
     }
 
     pub fn get_message<S: Message>(&self, region_id: u64, key: &[u8]) -> Result<Option<S>> {
-        let _t = StopWatch::new(&ENGINE_READ_MESSAGE_DURATION_HISTOGRAM);
+        let _t = StopWatch::new(&*ENGINE_READ_MESSAGE_DURATION_HISTOGRAM);
         if let Some(memtable) = self.memtables.get(region_id) {
             if let Some(value) = memtable.read().get(key) {
                 return Ok(Some(parse_from_bytes(&value)?));
@@ -215,7 +229,7 @@ where
         region_id: u64,
         log_idx: u64,
     ) -> Result<Option<M::Entry>> {
-        let _t = StopWatch::new(&ENGINE_READ_ENTRY_DURATION_HISTOGRAM);
+        let _t = StopWatch::new(&*ENGINE_READ_ENTRY_DURATION_HISTOGRAM);
         if let Some(memtable) = self.memtables.get(region_id) {
             if let Some(idx) = memtable.read().get_entry(log_idx) {
                 ENGINE_READ_ENTRY_COUNT_HISTOGRAM.observe(1.0);
@@ -243,7 +257,7 @@ where
         max_size: Option<usize>,
         vec: &mut Vec<M::Entry>,
     ) -> Result<usize> {
-        let _t = StopWatch::new(&ENGINE_READ_ENTRY_DURATION_HISTOGRAM);
+        let _t = StopWatch::new(&*ENGINE_READ_ENTRY_DURATION_HISTOGRAM);
         if let Some(memtable) = self.memtables.get(region_id) {
             let mut ents_idx: Vec<EntryIndex> = Vec::with_capacity((end - begin) as usize);
             memtable
@@ -382,7 +396,7 @@ where
         script: String,
         file_system: Arc<F>,
     ) -> Result<()> {
-        use crate::file_pipe_log::ReplayMachine;
+        use crate::file_pipe_log::{RecoveryConfig, ReplayMachine};
 
         if !path.exists() {
             return Err(Error::InvalidArgument(format!(
@@ -1769,6 +1783,37 @@ mod tests {
         assert_eq!(
             fs.append_metadata.lock().unwrap().iter().next().unwrap(),
             &start
+        );
+    }
+
+    #[test]
+    fn test_simple_write_perf_context() {
+        let dir = tempfile::Builder::new()
+            .prefix("test_simple_write_perf_context")
+            .tempdir()
+            .unwrap();
+        let cfg = Config {
+            dir: dir.path().to_str().unwrap().to_owned(),
+            ..Default::default()
+        };
+        let rid = 1;
+        let entry_size = 5120;
+        let engine = RaftLogEngine::open(cfg).unwrap();
+        let data = vec![b'x'; entry_size];
+        let old_perf_context = get_perf_context();
+        engine.append(rid, 1, 5, Some(&data));
+        let new_perf_context = get_perf_context();
+        assert_ne!(
+            old_perf_context.log_populating_duration,
+            new_perf_context.log_populating_duration
+        );
+        assert_ne!(
+            old_perf_context.log_write_duration,
+            new_perf_context.log_write_duration
+        );
+        assert_ne!(
+            old_perf_context.apply_duration,
+            new_perf_context.apply_duration
         );
     }
 }

--- a/src/file_pipe_log/log_file.rs
+++ b/src/file_pipe_log/log_file.rs
@@ -91,7 +91,7 @@ impl<F: FileSystem> LogFileWriter<F> {
     pub fn write(&mut self, buf: &[u8], target_size_hint: usize) -> Result<()> {
         let new_written = self.written + buf.len();
         if self.capacity < new_written {
-            let _t = StopWatch::new(&LOG_ALLOCATE_DURATION_HISTOGRAM);
+            let _t = StopWatch::new(&*LOG_ALLOCATE_DURATION_HISTOGRAM);
             let alloc = std::cmp::max(
                 new_written - self.capacity,
                 std::cmp::min(
@@ -111,7 +111,7 @@ impl<F: FileSystem> LogFileWriter<F> {
 
     pub fn sync(&mut self) -> Result<()> {
         if self.last_sync < self.written {
-            let _t = StopWatch::new(&LOG_SYNC_DURATION_HISTOGRAM);
+            let _t = StopWatch::new(&*LOG_SYNC_DURATION_HISTOGRAM);
             self.writer.sync()?;
             self.last_sync = self.written;
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -66,6 +66,7 @@ pub use config::{Config, RecoveryMode};
 pub use engine::Engine;
 pub use errors::{Error, Result};
 pub use log_batch::{Command, LogBatch, MessageExt};
+pub use metrics::{get_perf_context, set_perf_context, take_perf_context, PerfContext};
 pub use util::ReadableSize;
 
 #[cfg(feature = "internals")]

--- a/src/log_batch.rs
+++ b/src/log_batch.rs
@@ -11,9 +11,10 @@ use protobuf::Message;
 use crate::codec::{self, NumberEncoder};
 use crate::file_pipe_log::Version;
 use crate::memtable::EntryIndex;
+use crate::metrics::StopWatch;
 use crate::pipe_log::{FileBlockHandle, FileId};
 use crate::util::{crc32, lz4};
-use crate::{Error, Result};
+use crate::{perf_context, Error, Result};
 
 pub(crate) const LOG_BATCH_HEADER_LEN: usize = 16;
 pub(crate) const LOG_BATCH_CHECKSUM_LEN: usize = 4;
@@ -697,6 +698,7 @@ impl LogBatch {
     /// Internally, encodes and optionally compresses log entries. Sets the
     /// compression type to each entry index.
     pub(crate) fn finish_populate(&mut self, compression_threshold: usize) -> Result<usize> {
+        let _t = StopWatch::new(perf_context!(log_populating_duration));
         debug_assert!(self.buf_state == BufState::Open);
         if self.is_empty() {
             self.buf_state = BufState::Sealed(self.buf.len(), 0);

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,36 +1,152 @@
 // Copyright 2021 TiKV Project Authors. Licensed under Apache-2.0.
 
-use std::time::Instant;
+use std::{
+    cell::{RefCell, RefMut},
+    ops::AddAssign,
+    time::{Duration, Instant},
+};
 
 use prometheus::*;
 use prometheus_static_metric::*;
 
 use crate::util::InstantExt;
 
-pub struct StopWatch<'a> {
-    histogram: &'a Histogram,
+pub struct StopWatch<M: TimeMetric> {
+    metric: M,
     start: Instant,
 }
 
-impl<'a> StopWatch<'a> {
+impl<M: TimeMetric> StopWatch<M> {
     #[inline]
-    pub fn new(histogram: &'a Histogram) -> Self {
+    pub fn new(metric: M) -> Self {
         Self {
-            histogram,
+            metric,
             start: Instant::now(),
         }
     }
 
     #[inline]
-    pub fn new_with(histogram: &'a Histogram, start: Instant) -> Self {
-        Self { histogram, start }
+    pub fn new_with(metric: M, start: Instant) -> Self {
+        Self { metric, start }
     }
 }
 
-impl<'a> Drop for StopWatch<'a> {
+impl<M: TimeMetric> Drop for StopWatch<M> {
     fn drop(&mut self) {
-        self.histogram
-            .observe(self.start.saturating_elapsed().as_secs_f64());
+        self.metric.observe(self.start.saturating_elapsed());
+    }
+}
+
+/// PerfContext records cumulative performance statistics of operations.
+///
+/// Raft Engine will update the data in the thread-local PerfContext whenever
+/// an opeartion is performed.
+#[derive(Debug, Clone, Default)]
+pub struct PerfContext {
+    /// Time spent encoding and compressing log entries.
+    pub log_populating_duration: Duration,
+
+    /// Time spent waiting for the write group to form and get processed.
+    pub write_wait_duration: Duration,
+
+    /// Time spent writing the logs to files.
+    pub log_write_duration: Duration,
+
+    /// Time spent rotating the active log file.
+    pub log_rotate_duration: Duration,
+
+    // Time spent synchronizing logs to the disk.
+    pub log_sync_duration: Duration,
+
+    // Time spent applying the appended logs.
+    pub apply_duration: Duration,
+}
+
+impl AddAssign<&'_ PerfContext> for PerfContext {
+    fn add_assign(&mut self, rhs: &PerfContext) {
+        self.log_populating_duration += rhs.log_populating_duration;
+        self.write_wait_duration += rhs.write_wait_duration;
+        self.log_write_duration += rhs.log_write_duration;
+        self.log_rotate_duration += rhs.log_rotate_duration;
+        self.log_sync_duration += rhs.log_sync_duration;
+        self.apply_duration += rhs.apply_duration;
+    }
+}
+
+thread_local! {
+    static TLS_PERF_CONTEXT: RefCell<PerfContext> = RefCell::new(PerfContext::default());
+}
+
+/// Gets a copy of the thread-local PerfContext.
+pub fn get_perf_context() -> PerfContext {
+    TLS_PERF_CONTEXT.with(|c| c.borrow().clone())
+}
+
+/// Resets the thread-local PerfContext and takes its old value.
+pub fn take_perf_context() -> PerfContext {
+    TLS_PERF_CONTEXT.with(|c| c.take())
+}
+
+/// Sets the value of the thread-local PerfContext.
+pub fn set_perf_context(perf_context: PerfContext) {
+    TLS_PERF_CONTEXT.with(|c| *c.borrow_mut() = perf_context);
+}
+
+pub(crate) struct PerfContextField<P> {
+    projector: P,
+}
+
+impl<P> PerfContextField<P>
+where
+    P: Fn(&mut PerfContext) -> &mut Duration,
+{
+    pub fn new(projector: P) -> Self {
+        PerfContextField { projector }
+    }
+}
+
+#[macro_export(crate)]
+macro_rules! perf_context {
+    ($field: ident) => {
+        $crate::metrics::PerfContextField::new(|perf_context| &mut perf_context.$field)
+    };
+}
+
+pub trait TimeMetric {
+    fn observe(&self, duration: Duration);
+
+    fn observe_since(&self, earlier: Instant) -> Duration {
+        let dur = earlier.saturating_elapsed();
+        self.observe(dur);
+        dur
+    }
+}
+
+impl<'a> TimeMetric for &'a Histogram {
+    fn observe(&self, duration: Duration) {
+        Histogram::observe(self, duration.as_secs_f64());
+    }
+}
+
+impl<P> TimeMetric for PerfContextField<P>
+where
+    P: Fn(&mut PerfContext) -> &mut Duration,
+{
+    fn observe(&self, duration: Duration) {
+        TLS_PERF_CONTEXT.with(|perf_context| {
+            *RefMut::map(perf_context.borrow_mut(), &self.projector) += duration;
+        })
+    }
+}
+
+impl<M1, M2> TimeMetric for (M1, M2)
+where
+    M1: TimeMetric,
+    M2: TimeMetric,
+{
+    fn observe(&self, duration: Duration) {
+        self.0.observe(duration);
+        self.1.observe(duration);
     }
 }
 

--- a/src/purge.rs
+++ b/src/purge.rs
@@ -65,7 +65,7 @@ where
     }
 
     pub fn purge_expired_files(&self) -> Result<Vec<u64>> {
-        let _t = StopWatch::new(&ENGINE_PURGE_DURATION_HISTOGRAM);
+        let _t = StopWatch::new(&*ENGINE_PURGE_DURATION_HISTOGRAM);
         let guard = self.force_rewrite_candidates.try_lock();
         if guard.is_none() {
             warn!("Unable to purge expired files: locked");
@@ -202,7 +202,7 @@ where
         compact_watermark: FileSeq,
         rewrite_candidates: &mut HashMap<u64, u32>,
     ) -> Result<Vec<u64>> {
-        let _t = StopWatch::new(&ENGINE_REWRITE_APPEND_DURATION_HISTOGRAM);
+        let _t = StopWatch::new(&*ENGINE_REWRITE_APPEND_DURATION_HISTOGRAM);
         debug_assert!(compact_watermark <= rewrite_watermark);
         let mut should_compact = Vec::with_capacity(16);
 
@@ -239,7 +239,7 @@ where
 
     // Rewrites the entire rewrite queue into new log files.
     fn rewrite_rewrite_queue(&self) -> Result<Vec<u64>> {
-        let _t = StopWatch::new(&ENGINE_REWRITE_REWRITE_DURATION_HISTOGRAM);
+        let _t = StopWatch::new(&*ENGINE_REWRITE_REWRITE_DURATION_HISTOGRAM);
         self.pipe_log.rotate(LogQueue::Rewrite)?;
 
         let mut force_compact_regions = vec![];

--- a/tests/failpoints/test_engine.rs
+++ b/tests/failpoints/test_engine.rs
@@ -1,6 +1,7 @@
 // Copyright (c) 2017-present, PingCAP, Inc. Licensed under Apache-2.0.
 
-use std::sync::Arc;
+use std::sync::{Arc, Barrier};
+use std::time::Duration;
 
 use kvproto::raft_serverpb::RaftLocalState;
 use raft::eraftpb::Entry;
@@ -39,7 +40,6 @@ fn append<FS: FileSystem>(
 fn test_pipe_log_listeners() {
     use std::collections::HashMap;
     use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
-    use std::time::Duration;
 
     #[derive(Default)]
     struct QueueHook {
@@ -450,5 +450,69 @@ fn test_tail_corruption() {
         append(&engine, rid, 1, 5, Some(&data));
         drop(engine);
         assert!(Engine::open_with_file_system(cfg, fs).is_err());
+    }
+}
+
+#[test]
+fn test_concurrent_write_perf_context() {
+    let dir = tempfile::Builder::new()
+        .prefix("test_concurrent_write_perf_context")
+        .tempdir()
+        .unwrap();
+    let cfg = Config {
+        dir: dir.path().to_str().unwrap().to_owned(),
+        ..Default::default()
+    };
+
+    let some_entries = vec![
+        Entry::new(),
+        Entry {
+            index: 1,
+            ..Default::default()
+        },
+    ];
+
+    let engine = Arc::new(Engine::open(cfg).unwrap());
+    let barrier = Arc::new(Barrier::new(4));
+
+    let ths: Vec<_> = (1..=3)
+        .map(|i| {
+            let engine = engine.clone();
+            let barrier = barrier.clone();
+            let some_entries = some_entries.clone();
+            std::thread::spawn(move || {
+                barrier.wait();
+                let mut log_batch = LogBatch::default();
+                log_batch
+                    .add_entries::<MessageExtTyped>(i, &some_entries)
+                    .unwrap();
+                let old_perf_context = get_perf_context();
+                engine.write(&mut log_batch, true).unwrap();
+                let new_perf_context = get_perf_context();
+                (old_perf_context, new_perf_context)
+            })
+        })
+        .collect();
+
+    fail::cfg_callback("write_barrier::leader_exit", move || {
+        barrier.wait();
+        // Sleep a while until new writers enter the next write group.
+        std::thread::sleep(Duration::from_millis(100));
+        fail::remove("write_barrier::leader_exit");
+    })
+    .unwrap();
+
+    let mut log_batch = LogBatch::default();
+    log_batch
+        .add_entries::<MessageExtTyped>(4, &some_entries)
+        .unwrap();
+    engine.write(&mut log_batch, true).unwrap();
+
+    for th in ths {
+        let (old, new) = th.join().unwrap();
+        assert_ne!(old.log_populating_duration, new.log_populating_duration);
+        assert_ne!(old.write_wait_duration, new.write_wait_duration);
+        assert_ne!(old.log_write_duration, new.log_write_duration);
+        assert_ne!(old.apply_duration, new.apply_duration);
     }
 }


### PR DESCRIPTION
* Record perf contexts to the write procedure

Signed-off-by: Yilin Chen <sticnarf@gmail.com>

* change perf context to use Duration and add observe_since

Signed-off-by: Yilin Chen <sticnarf@gmail.com>

* add a bit more comments about perf context collecting in write

Signed-off-by: Yilin Chen <sticnarf@gmail.com>

* Address some comments, add tests and changelog

Signed-off-by: Yilin Chen <sticnarf@gmail.com>

* address comment

Signed-off-by: Yilin Chen <sticnarf@gmail.com>

* address more comments

Signed-off-by: Yilin Chen <sticnarf@gmail.com>